### PR TITLE
[PR] MPAttendance 엔티티 Lazy 로딩 직렬화 오류 수정

### DIFF
--- a/src/main/java/com/wanted/legendkim/domain/mypage/entity/MPAttendance.java
+++ b/src/main/java/com/wanted/legendkim/domain/mypage/entity/MPAttendance.java
@@ -1,5 +1,6 @@
 package com.wanted.legendkim.domain.mypage.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Getter
 @ToString
+@JsonIgnoreProperties({"userId", "hibernateLazyInitializer", "handler"})
 @Entity
 @Table(name = "attendance")
 public class MPAttendance {


### PR DESCRIPTION
📌 작업 내용
MPAttendance 엔티티에 @JsonIgnoreProperties 어노테이션을 추가하여 출결 조회 페이지 캘린더에 데이터가 표시되지 않던 문제를 수정했습니다.

🐛 문제 원인
MPAttendance 엔티티의 userId 필드가 @ManyToOne(fetch = FetchType.LAZY)로 설정되어 있어, Thymeleaf가 해당 엔티티를 JavaScript 변수(rawAttendanceData)로 직렬화하는 과정에서 Lazy 로딩 예외가 발생했습니다.
그 결과 attendanceList가 빈 배열 []로 내려와 캘린더에 출결 데이터가 전혀 표시되지 않았습니다.


✅ 수정 내용
MPAttendance.java
java// 추가
@JsonIgnoreProperties({"userId", "hibernateLazyInitializer", "handler"})
직렬화 시 userId (연관 엔티티) 및 Hibernate 내부 프록시 필드를 제외하도록 설정했습니다.

🧪 테스트

lee.daeri@legeno.com 계정으로 출결 조회 페이지 접속
캘린더에 출근(PRESENT) / 지각(LATE) / 결근(ABSENT) / 공결(EXCUSED) 정상 표시 확인