### PR TITLE
[Refactory] FE 영역 잘못된 경로 수정

### DIFF
--- a/src/main/resources/templates/mypage/adminattendance.html
+++ b/src/main/resources/templates/mypage/adminattendance.html
@@ -66,7 +66,7 @@
                     </a>
                 </li>
                 <li>
-                    <a href="javascript:void(0)" onclick="checkAccess('/user/enrollments', true)" class="flex items-center px-6 py-3 text-gray-500 hover:bg-white hover:text-[#1A237E] transition-all">
+                    <a href="javascript:void(0)" onclick="checkAccess('/user/enrollments/list', true)" class="flex items-center px-6 py-3 text-gray-500 hover:bg-white hover:text-[#1A237E] transition-all">
                         <svg class="w-5 h-5 mr-3" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="9"/><path d="M12 8v4l3 3"/></svg>
                         <span class="text-sm font-medium">수강신청</span>
                     </a>

--- a/src/main/resources/templates/questionboard/user/questionboard.html
+++ b/src/main/resources/templates/questionboard/user/questionboard.html
@@ -69,7 +69,7 @@
                     마이페이지
                 </a>
 
-                <a th:href="@{/user/enrollment/list}" class="nav-item">
+                <a th:href="@{/user/enrollments/list}" class="nav-item">
                     수강신청
                 </a>
 


### PR DESCRIPTION
  ## Summary
  - 관리자 출결관리 페이지와 문제 게시판 페이지의 `수강신청` 네비게이션 링크가 잘못된 URL을 가리켜 404가 발생하던 이슈를 수정
  - 실제 경로 `/user/enrollments/list` (SectionViewController)에 맞춰 통일

  ## 변경 내역
  | 파일 | Before | After |
  |---|---|---|
  | `templates/questionboard/user/questionboard.html` (L72) | `/user/enrollment/list` (단수형 오타) | `/user/enrollments/list` |
  | `templates/mypage/adminattendance.html` (L69) | `/user/enrollments` (`/list` 누락) | `/user/enrollments/list` |

  ## Test plan
  - [x] 문제 게시판 진입 → 좌측 `수강신청` 클릭 → 수강신청 목록 정상 렌더링
  - [x] 관리자 출결관리 진입 → 좌측 `수강신청` 클릭 → 수강신청 목록 정상 렌더링
  - [x] 기존 정상 동작하던 다른 네비게이션 링크(마이페이지, 문제게시판, 자유게시판) 회귀 없음 확인